### PR TITLE
Rename max_exp_time to min_exptime

### DIFF
--- a/astroquery_example_kbos.ipynb
+++ b/astroquery_example_kbos.ipynb
@@ -148,7 +148,7 @@
     "kbo_name = '2006 WG206'\n",
     "start_date = '2007 01 18'\n",
     "end_date = '2007 01 19'\n",
-    "max_exp_time = 20\n",
+    "min_exp_time = 20\n",
     "\n",
     "# Build query url\n",
     "params = {\n",
@@ -169,7 +169,7 @@
     "data_table = pd.read_csv(url, sep='\\t')\n",
     "\n",
     "# Get results with a long exposure and the g-band filter\n",
-    "data_table = data_table[(data_table['Exptime'] > max_exp_time)\n",
+    "data_table = data_table[(data_table['Exptime'] > min_exp_time)\n",
     "                        & (data_table['Filter'] == \"G.MP9401\")]\n",
     "\n",
     "data_table"


### PR DESCRIPTION
The max_exp_time variable was used to set the min_exp_time, renamed to better reflect variable usage.